### PR TITLE
Basic CLI

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const { command, flag } = require('paparam')
+const goodbye = require('graceful-goodbye')
+const idEnc = require('hypercore-id-encoding')
+const BlindPeer = require('.')
+
+const cmd = command('blind-peer',
+  flag('--storage|-s [path]', 'storage path, defaults to ./blind-peer'),
+  async function ({ flags }) {
+    console.info('Starting blind peer')
+
+    const storage = flags.storage || 'blind-peer'
+    const blindPeer = new BlindPeer(storage)
+
+    console.info(`Using storage '${storage}'`)
+
+    goodbye(async () => {
+      console.info('Shutting down blind peer')
+      await blindPeer.close()
+    })
+
+    await blindPeer.listen()
+
+    console.info(`Listening at ${idEnc.normalize(blindPeer.publicKey)}`)
+  }
+)
+
+cmd.parse()

--- a/example/autobase.mjs
+++ b/example/autobase.mjs
@@ -4,6 +4,7 @@ import c from 'compact-encoding'
 import Corestore from 'corestore'
 import Hyperswarm from 'hyperswarm'
 import debounce from 'debounceify'
+import IdEnc from 'hypercore-id-encoding'
 
 const base = new Autobase(new Corestore('/tmp/my-corestore'), {
   encryptionKey: Buffer.alloc(30).fill('secret'),
@@ -31,7 +32,7 @@ base.view.on('append', debounce(async function () {
 }))
 
 // TODO: record in autobase
-const publicKey = Buffer.from(process.argv[2], 'hex')
+const publicKey = IdEnc.decode(process.argv[2])
 
 const s = new Hyperswarm({ keyPair: await base.store.createKeyPair('tmp') })
 

--- a/example/post.mjs
+++ b/example/post.mjs
@@ -1,8 +1,9 @@
 import BlindPeerClient from '../client.js'
 import Hyperswarm from 'hyperswarm'
+import IdEnc from 'hypercore-id-encoding'
 
-const publicKey = Buffer.from(process.argv[2], 'hex')
-const autobase = Buffer.from(process.argv[3], 'hex')
+const publicKey = IdEnc.decode(process.argv[2])
+const autobase = IdEnc.decode(process.argv[3])
 const rawMessage = process.argv[4]
 const message = Buffer.from(
   JSON.stringify({ mailbox: true, message: rawMessage })

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
   "version": "0.0.2",
   "description": "WIP - nothing to see here",
   "main": "index.js",
+  "bin": {
+    "blind-peer": "bin.js"
+  },
   "dependencies": {
     "autobase-light-writer": "^1.1.0",
     "corestore": "^6.18.4",
+    "graceful-goodbye": "^1.3.2",
+    "hypercore-id-encoding": "^1.3.0",
     "hyperdb": "^4.1.2",
     "hyperschema": "^1.0.3",
     "hyperswarm": "^4.8.4",
+    "paparam": "^1.6.1",
     "protomux-rpc": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A CLI equivalent of the example/blind-peer.mjs script.

Note: updated the examples to support both hex and z32 keys