### PR TITLE
Log mailbox id on add-request

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -15,7 +15,7 @@ const cmd = command('blind-peer',
 
     blindPeer.on('add-request', req => {
       try {
-        console.log(`Add-mailbox request received for autobase ${idEnc.normalize(req.autobase)}`)
+        console.log(`Add-mailbox request received for autobase ${idEnc.normalize(req.autobase)} (mailbox id: ${idEnc.normalize(req.id)})`)
       } catch {
         console.log('Invalid add-mailbox request received')
         console.log(req)
@@ -24,7 +24,7 @@ const cmd = command('blind-peer',
 
     blindPeer.on('post-request', req => {
       try {
-        console.log(`Post request received to autobase ${idEnc.normalize(req.autobase)}`)
+        console.log(`Post request received for mailbox ${idEnc.normalize(req.id)}`)
       } catch {
         console.log('Invalid post request received')
         console.log(req)


### PR DESCRIPTION
Context: post requests now target a mailbox id instead of an autobase