### PR TITLE
Fix db-flushes stat

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -129,8 +129,6 @@ module.exports = class BlindPeerDB extends ReadyResource {
     }
 
     if (addedCores || addedReferrers || bytesAllocated || this.closing) {
-      this.stats.flushes++ // we only count those flushes where we update the db
-
       this.digest.cores += addedCores
       this.digest.referrers += addedReferrers
       this.digest.bytesAllocated += bytesAllocated
@@ -139,6 +137,7 @@ module.exports = class BlindPeerDB extends ReadyResource {
       await tx.insert('@blind-peer/digest', this.digest)
     }
 
+    if (tx.updates.size > 0) this.stats.flushes++ // we only count those flushes where we update the db
     await tx.flush()
   }
 


### PR DESCRIPTION
It was undercounting before (individual cores in the db can be updated without there being a digest update).