### PR TITLE
Log invalid requests

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -88,6 +88,13 @@ const cmd = command('blind-peer',
       })
     }
 
+    blindPeer.on('invalid-request', (core, err, req, from) => {
+      const address = `${from.stream?.rawStream?.remoteHost}:${from.stream?.rawStream?.remotePort}`
+      const remotePubKey = idEnc.normalize(from.stream.remotePublicKey)
+      const key = idEnc.normalize(core.key)
+      console.warn(`Received invalid request for core ${key} from peer ${remotePubKey} at ${address} (${err.stack})`)
+    })
+
     logger.info(`Using storage '${storage}'`)
     if (trustedPubKeys.length > 0) {
       logger.info(`Trusted public keys:\n  -${[...blindPeer.trustedPubKeys].map(idEnc.normalize).join('\n  -')}`)

--- a/index.js
+++ b/index.js
@@ -331,6 +331,9 @@ class BlindPeer extends ReadyResource {
         this.activeReplication.delete(id)
       }
     })
+    session.on('invalid-request', (err, req, from) => {
+      this.emit('invalid-request', session, err, req, from)
+    })
   }
 
   async flush () { // not allowed to throw


### PR DESCRIPTION
The logs look like

```
Received invalid request for core ab15oynn3pipkp7uggziej8w5yexkwdjmy7bp76gz7q5cf64nj7y from peer 7xicfxdy888g5rf57k8kqys56wspyubpno5jb78afegiw3fws67o at 192.168.0.203:50798 (HypercoreError: INVALID_OPERATION: Cannot both do a seek and block/hash request when upgrading
    at generateProof (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/merkle-tree.js:1206:11)
    at MerkleTree.proof (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/merkle-tree.js:666:12)
    at Peer._getProof (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/replicator.js:735:38)
    at Peer._handleRequest (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/replicator.js:801:20)
    at Peer.onrequest (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/replicator.js:766:16)
    at Object.onwirerequest [as onmessage] (/home/hans/holepunch/blind-peer/node_modules/hypercore/lib/replicator.js:2680:21)
    at Object.recv (/home/hans/holepunch/blind-peer/node_modules/protomux/index.js:251:33)
    at Channel._recv (/home/hans/holepunch/blind-peer/node_modules/protomux/index.js:203:19)
    at Protomux._decode (/home/hans/holepunch/blind-peer/node_modules/protomux/index.js:521:22)
    at Protomux._ondata (/home/hans/holepunch/blind-peer/node_modules/protomux/index.js:486:12))
```