### PR TITLE
Bugfix: allow upgrading announce

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,10 +426,11 @@ class BlindPeer extends ReadyResource {
       record.announce = false
     }
 
-    // We only add it to the db the first time (prio, announce etc can't be changed)
+    // We only add it to the db the first time, except if announce changed
     // Note: not race condition safe, but it's no problem if we do add the same core twice
     const existing = await this.db.getCoreRecord(record.key)
-    if (!existing) {
+    const upgradeToAnnounce = existing && !existing.announce && record.announce
+    if (!existing || upgradeToAnnounce) {
       this.db.addCore(record)
       await this.flush() // flush now as important data
     }

--- a/test/test.js
+++ b/test/test.js
@@ -517,6 +517,7 @@ test('Trusted peers can update an existing record to start announcing it', async
 
     const [record] = await coreAddedProm
     t.is(record.announce, true, 'announce set in db')
+    t.is((await blindPeer.db.getCoreRecord(record.key)).announce, true)
   }
 
   await swarm.destroy()


### PR DESCRIPTION
Previous behaviour when adding an announced core when it already existed was complex:
- The core was announced, due to the `await this._activateCore(stream, record)` call
- But the DB record did not get updated, so kept `announced: false

This meant that, after a restart, the core would not be announced anymore.

