### PR TITLE
Fix close race conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ class CoreTracker {
   }
 
   _onupdate() {
+    if (this.blindPeer.closing) return
+
     this.updated = true
     if (!this.record) return
 
@@ -65,6 +67,8 @@ class CoreTracker {
   }
 
   _onactive() {
+    if (this.blindPeer.closing) return
+
     this.activated = true
 
     if (this.record) {
@@ -626,6 +630,7 @@ class BlindPeer extends ReadyResource {
     let activeSession = null
 
     core.on('append', () => {
+      if (this.closing) return
       const replicationLag = core.length - core.contiguousLength
       if (!activeSession.isClient && replicationLag > this.replicationLagThreshold) {
         activeSession.refresh({ server: true, client: true })
@@ -635,6 +640,7 @@ class BlindPeer extends ReadyResource {
       this.emit('core-append', core)
     })
     core.on('download', () => {
+      if (this.closing) return
       const replicationLag = core.length - core.contiguousLength
       if (replicationLag === 0) {
         if (activeSession.isClient) {


### PR DESCRIPTION
The on('download') one triggers reliably now, something must have changed upstream

See e.g. failing run https://github.com/holepunchto/blind-peer/actions/runs/25882597153/job/76066126918 (trivial to repro locally, fails ~1/2 times).

The others I don't think are an issue in practice, but can't hurt to early return on closing either