### PR TITLE
Explicitly destroy downloadRanges on gc

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ class CoreTracker {
     if (this.destroyed || this.record || !record) return
 
     this.record = record
-    this.core.download({ start: this.record.blocksCleared, end: -1 })
+    this.downloadRange = this.core.download({ start: this.record.blocksCleared, end: -1 })
 
     if (this.updated) this._onupdate()
     if (this.activated) this._onactive()

--- a/index.js
+++ b/index.js
@@ -144,6 +144,7 @@ class CoreTracker {
   destroy() {
     if (this.destroyed) return
     this.destroyed = true
+    this.downloadRange.destroy()
   }
 }
 


### PR DESCRIPTION
I haven't fully figured out if this is a bug in practice