### PR TITLE
Early-return refresh if record already set

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ class CoreTracker {
   }
 
   async refresh() {
+    if (this.destroyed || this.record)
+
     await this.core.ready()
     if (this.destroyed) return
 

--- a/index.js
+++ b/index.js
@@ -98,9 +98,7 @@ class CoreTracker {
   }
 
   async refresh() {
-    if (this.destroyed || this.record)
-
-    await this.core.ready()
+    if (this.destroyed || this.record) await this.core.ready()
     if (this.destroyed) return
 
     this.id = this.core.id

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ class CoreTracker {
   async refresh() {
     if (this.destroyed || this.record) return
     await this.core.ready()
+    if (this.destroyed) return
 
     this.id = this.core.id
     this.channel = 'hypercore/alpha##' + b4a.toString(this.core.discoveryKey, 'hex')

--- a/index.js
+++ b/index.js
@@ -439,7 +439,7 @@ class BlindPeer extends ReadyResource {
 
       try {
         const tracker = this.activeReplication.get(id)
-        if (!tracker.record) await tracker.refresh()
+        await tracker.refresh()
         const coreBytesCleared = tracker.gc()
         bytesCleared += coreBytesCleared
       } finally {
@@ -576,7 +576,7 @@ class BlindPeer extends ReadyResource {
     await core.ready()
 
     const tracker = this.activeReplication.get(b4a.toString(core.discoveryKey, 'hex'))
-    if (tracker && !tracker.record) await tracker.refresh()
+    if (tracker) await tracker.refresh()
 
     if (record.announce) {
       await this._announceCore(core.key)

--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ class CoreTracker {
   }
 
   async refresh() {
-    if (this.destroyed || this.record) await this.core.ready()
-    if (this.destroyed) return
+    if (this.destroyed || this.record) return
+    await this.core.ready()
 
     this.id = this.core.id
     this.channel = 'hypercore/alpha##' + b4a.toString(this.core.discoveryKey, 'hex')


### PR DESCRIPTION
once this.record is set, the guard after getting the record (`if (this.destroyed || this.record || !record) return`) always early returns, so we might as well return immediately and avoid the lookup