### PR TITLE
Add support for passing `treeCache` options to `corestore`

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,13 +232,14 @@ class BlindPeer extends ReadyResource {
       replicationLagThreshold = 100,
       topK = {},
       adminRouter = null,
-      activeCorestore = false
+      activeCorestore = false,
+      treeCache
     } = {}
   ) {
     super()
 
     this.rocks = typeof rocks === 'string' ? new RocksDB(rocks) : rocks
-    this.store = store || new Corestore(this.rocks, { active: activeCorestore })
+    this.store = store || new Corestore(this.rocks, { active: activeCorestore, treeCache })
     this.swarm = swarm || null
     const ipBanNs = this.store.namespace('ip-ban-lists')
     this.ipBanLists = ipBanListKeys.map((key) => new IpBanList(ipBanNs, { key }))

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,16 @@ test('client can use a blind-peer to add a core', async (t) => {
   }
 })
 
+test('blind-peer can set treeCache options for corestore', async (t) => {
+  const dir = await tmpDir(t)
+  const blindPeer = new BlindPeer(dir, { treeCache: { maxSize: 2 ** 17, maxAge: 1337 } })
+  t.teardown(() => blindPeer.close())
+  await blindPeer.ready()
+
+  t.is(blindPeer.store.storage.treeCache.maxSize, 2 ** 17, 'got maxSize')
+  t.is(blindPeer.store.storage.treeCache.maxAge, 1337, 'got maxAge')
+})
+
 test('client can ask a blind-peer to create and forward a push notification', async (t) => {
   const { bootstrap } = await getTestnet(t)
 


### PR DESCRIPTION
Allows setting options for the tree node cache via the constructor (where the Corestore is created).

Depends on:

- https://github.com/holepunchto/corestore/pull/152