### PR TITLE
Bugfix: no new session for repeated activations

### DIFF
--- a/index.js
+++ b/index.js
@@ -574,7 +574,7 @@ class BlindPeer extends ReadyResource {
 
     const replicatingCores = new Map()
     this._coresPerConnection.set(conn, replicatingCores)
-    conn.on('close', () => {
+    conn.once('close', () => {
       this._coresPerConnection.delete(conn)
       for (const core of replicatingCores.values()) core.close().catch(safetyCatch)
     })
@@ -663,11 +663,14 @@ class BlindPeer extends ReadyResource {
 
     const id = b4a.toString(record.key, 'hex')
     const replicatingCores = this._coresPerConnection.get(stream)
+    if (!replicatingCores) return // race condition
     if (replicatingCores.has(id)) return // already replicating
 
-    const core = this.store.get(record.key)
+    const core = this.store.get({ key: record.key })
     replicatingCores.set(id, core)
     await core.ready()
+
+    if (stream.destroying) return
     core.replicate(stream)
   }
 

--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ class BlindPeer extends ReadyResource {
     this.lock = new ScopeLock({ debounce: true })
     this.announcedCores = new Map()
     this.replicationLagThreshold = replicationLagThreshold
+    this._coresPerConnection = new Map()
 
     this.rpcClient = null
     this.routerKey = routerKey || null
@@ -440,7 +441,6 @@ class BlindPeer extends ReadyResource {
 
     if (session.hasStream(stream)) return
     session.addStream(stream)
-
     // if new peer, send back the active handler for this peer
     const peer = session.getPeer(stream)
     if (peer && peer.active) session.handlers.onpeeractive(peer, session)
@@ -572,6 +572,13 @@ class BlindPeer extends ReadyResource {
     if (this.ownsStore) this.store.replicate(conn)
     if (this.ownsWakeup) this.wakeup.addStream(conn)
 
+    const replicatingCores = new Map()
+    this._coresPerConnection.set(conn, replicatingCores)
+    conn.on('close', () => {
+      this._coresPerConnection.delete(conn)
+      for (const core of replicatingCores.values()) core.close().catch(safetyCatch)
+    })
+
     const rpc = new ProtomuxRPC(conn, {
       id: this.swarm.keyPair.publicKey,
       valueEncoding: c.none
@@ -643,23 +650,25 @@ class BlindPeer extends ReadyResource {
   async _activateCore(stream, record, force) {
     this.stats.activations++
 
-    const core = this.store.get({ key: record.key })
-    await core.ready()
+    const discKey = crypto.discoveryKey(record.key)
 
-    const tracker = this.activeReplication.get(b4a.toString(core.discoveryKey, 'hex'))
+    const tracker = this.activeReplication.get(b4a.toString(discKey, 'hex'))
     if (tracker) await tracker.refresh(force)
 
     if (record.announce) {
-      await this._announceCore(core.key)
+      await this._announceCore(record.key)
     }
 
-    if (stream.destroying) {
-      await core.close()
-      return
-    }
+    if (stream.destroying) return
 
+    const id = b4a.toString(record.key, 'hex')
+    const replicatingCores = this._coresPerConnection.get(stream)
+    if (replicatingCores.has(id)) return // already replicating
+
+    const core = this.store.get(record.key)
+    replicatingCores.set(id, core)
+    await core.ready()
     core.replicate(stream)
-    stream.on('close', () => core.close().catch(safetyCatch))
   }
 
   async _resolvePeers(key) {

--- a/index.js
+++ b/index.js
@@ -281,6 +281,7 @@ class BlindPeer extends ReadyResource {
       bytesGcd: 0,
       coresAdded: 0,
       activations: 0,
+      activatedReplications: 0,
       wakeups: 0,
       addCoresRx: 0,
       notificationsRx: 0,
@@ -344,6 +345,12 @@ class BlindPeer extends ReadyResource {
 
   get nrAnnouncedCores() {
     return this.announcedCores.size
+  }
+
+  getActiveReplicationSessions() {
+    let res = 0
+    for (const actives of this._coresPerConnection.values()) res += actives.size
+    return res
   }
 
   addTrustedPubKey(key) {
@@ -672,6 +679,8 @@ class BlindPeer extends ReadyResource {
 
     if (stream.destroying) return
     core.replicate(stream)
+
+    this.stats.activatedReplications++
   }
 
   async _resolvePeers(key) {
@@ -1127,6 +1136,22 @@ class BlindPeer extends ReadyResource {
 
     new promClient.Gauge({
       // eslint-disable-line no-new
+      name: 'blind_peer_active_replication_sessions',
+      help: 'The total amount of hypercore replication sessions currently explicitly tracked',
+      collect() {
+        this.set(self.getActiveReplicationSessions())
+      }
+    })
+
+    new promClient.Gauge({
+      name: 'blind_peer_replication_sessions_opened',
+      help: 'The total amount of hypercore replication sessions ever opened',
+      collect() {
+        this.set(self.stats.activatedReplications)
+      }
+    })
+
+    new promClient.Gauge({
       name: 'blind_peer_wakeups',
       help: 'The total amount of hypercore wakeups since the process started',
       collect() {

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,7 @@ const { ADMIN_CHANNEL_ID, AdminQueryTopKEncoding } = require('blind-peer-encodin
 const blindPush = require('blind-push')
 const BlindPushGateway = require('blind-push-gateway')
 const rrp = require('resolve-reject-promise')
+const HypercoreStats = require('hypercore-stats')
 
 const BlindPeer = require('..')
 const TopKWindow = require('../lib/top-k.js')
@@ -302,7 +303,8 @@ test('sets up core replication on notification if not present and the core is ou
 
   const client = new Client(swarm2.dht, store2, { keys: [blindPeer.publicKey] })
 
-  blindPeer.on('notification-error', () => {
+  blindPeer.on('notification-error', (e) => {
+    console.error(e)
     t.fail('notification should work')
   })
 
@@ -2485,6 +2487,50 @@ test('coreTracker does not leak when core closes before refresh completes', asyn
 
   t.is(blindPeer.activeReplication.size, 0, 'activeReplication entry removed after core closed')
   t.is(blindPeer.stats.coreTrackersDestroyed, 1, 'core trackers destroyed stat')
+})
+
+test('activating the same core repeatedly does not leak hypercore sessions and stream close listeners', async (t) => {
+  // Repeated add-core requests happen when an autobase changes,
+  // but to keep the tests simple we hack into the muxer directly
+  // (the test is for the server side anyway)
+
+  const { bootstrap } = await getTestnet(t)
+
+  const { blindPeer } = await setupBlindPeer(t, bootstrap)
+  await blindPeer.listen()
+  await blindPeer.swarm.flush()
+
+  const { core, swarm, store } = await setupCoreHolder(t, bootstrap, { active: false })
+
+  const connProm = once(blindPeer.swarm, 'connection')
+  const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
+  const [conn] = await connProm
+
+  const closeListeners = () => conn.listenerCount('close')
+  const initListeners = closeListeners()
+
+  for (let i = 0; i < 5; i++) {
+    await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
+    await Promise.all([
+      once(blindPeer, 'add-cores-done'),
+      muxer.addCores({
+        referrer: core.key,
+        priority: 0,
+        announce: false,
+        cores: [{ key: core.key, length: core.length }]
+      })
+    ])
+  }
+
+  t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation')
+  const bpCore = blindPeer.store.get(core.key)
+  await bpCore.ready()
+  console.log('sessions', bpCore.sessions.length)
+
+  t.is(closeListeners() - initListeners, 1, `no close listener leak`)
+  t.is(bpCore.sessions.length, 2, 'no new session per request')
+
+  await muxer.close()
 })
 
 async function setupCoreHolder(t, bootstrap, { active } = {}) {

--- a/test/test.js
+++ b/test/test.js
@@ -2535,7 +2535,6 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
   t.is(blindPeer.getActiveReplicationSessions(), 1, 'blind peers own view correct')
   t.is(blindPeer.stats.activatedReplications, 1, 'blind peers own stat correct')
   await Promise.all([new Promise((resolve) => conn.once('close', resolve)), muxer.stream.destroy()])
-  // await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
   t.is(blindPeer.getActiveReplicationSessions(), 0, 'blind peers own stat correct')
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -2514,9 +2514,6 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
     await Promise.all([
       once(blindPeer, 'add-cores-done'),
       muxer.addCores({
-        referrer: core.key,
-        priority: 0,
-        announce: false,
         cores: [{ key: core.key, length: core.length }]
       })
     ])

--- a/test/test.js
+++ b/test/test.js
@@ -2521,7 +2521,6 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
   t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation')
   const bpCore = blindPeer.store.get(core.key)
   await bpCore.ready()
-  console.log('sessions', bpCore.sessions.length)
 
   t.is(closeListeners() - initListeners, 1, `no close listener leak`)
   t.is(bpCore.sessions.length, 2, 'no new session per request')

--- a/test/test.js
+++ b/test/test.js
@@ -2496,52 +2496,49 @@ test('coreTracker does not leak when core closes before refresh completes', asyn
   t.is(blindPeer.stats.coreTrackersDestroyed, 1, 'core trackers destroyed stat')
 })
 
-test(
-  'activating the same core repeatedly does not leak hypercore sessions and stream close listeners',
-  async (t) => {
-    // Repeated add-core requests happen when an autobase changes,
-    // but to keep the tests simple we hack into the muxer directly
-    // (the test is for the server side anyway)
+test('activating the same core repeatedly does not leak hypercore sessions and stream close listeners', async (t) => {
+  // Repeated add-core requests happen when an autobase changes,
+  // but to keep the tests simple we hack into the muxer directly
+  // (the test is for the server side anyway)
 
-    const { bootstrap } = await getTestnet(t)
+  const { bootstrap } = await getTestnet(t)
 
-    const { blindPeer } = await setupBlindPeer(t, bootstrap)
-    await blindPeer.listen()
-    await blindPeer.swarm.flush()
+  const { blindPeer } = await setupBlindPeer(t, bootstrap)
+  await blindPeer.listen()
+  await blindPeer.swarm.flush()
 
-    const { core, swarm, store } = await setupCoreHolder(t, bootstrap, { active: false })
+  const { core, swarm, store } = await setupCoreHolder(t, bootstrap, { active: false })
 
-    const connProm = once(blindPeer.swarm, 'connection')
-    const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
-    const [conn] = await connProm
+  const connProm = once(blindPeer.swarm, 'connection')
+  const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
+  const [conn] = await connProm
 
-    const closeListeners = () => conn.listenerCount('close')
-    const initListeners = closeListeners()
+  const closeListeners = () => conn.listenerCount('close')
+  const initListeners = closeListeners()
 
-    for (let i = 0; i < 5; i++) {
-      await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
-      await Promise.all([
-        once(blindPeer, 'add-cores-done'),
-        muxer.addCores({
-          cores: [{ key: core.key, length: core.length }]
-        })
-      ])
-    }
-
-    t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
-
-    t.is(closeListeners() - initListeners, 1, `no close listener leak`)
-
-    const bpCore = blindPeer.store.get(core.key)
-    await bpCore.ready()
-    t.is(bpCore.sessions.length, 2, 'no new session per request')
-    t.is(blindPeer.getActiveReplicationSessions(), 1, 'blind peers own view correct')
-    t.is(blindPeer.stats.activatedReplications, 1, 'blind peers own stat correct')
-    await muxer.stream.destroy()
-    await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
-    t.is(blindPeer.getActiveReplicationSessions(), 0, 'blind peers own stat correct')
+  for (let i = 0; i < 5; i++) {
+    await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
+    await Promise.all([
+      once(blindPeer, 'add-cores-done'),
+      muxer.addCores({
+        cores: [{ key: core.key, length: core.length }]
+      })
+    ])
   }
-)
+
+  t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
+
+  t.is(closeListeners() - initListeners, 1, `no close listener leak`)
+
+  const bpCore = blindPeer.store.get(core.key)
+  await bpCore.ready()
+  t.is(bpCore.sessions.length, 2, 'no new session per request')
+  t.is(blindPeer.getActiveReplicationSessions(), 1, 'blind peers own view correct')
+  t.is(blindPeer.stats.activatedReplications, 1, 'blind peers own stat correct')
+  await muxer.stream.destroy()
+  await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
+  t.is(blindPeer.getActiveReplicationSessions(), 0, 'blind peers own stat correct')
+})
 
 async function setupCoreHolder(t, bootstrap, { active } = {}) {
   const { swarm, store } = await setupPeer(t, bootstrap, { active })

--- a/test/test.js
+++ b/test/test.js
@@ -1893,6 +1893,14 @@ test('Prometheus metrics', async (t) => {
     t.ok(metrics.includes('blind_peer_cores_added 0'), 'blind_peer_cores_added included')
     t.ok(metrics.includes('blind_peer_cores 0'), 'blind_peer_cores included')
     t.ok(metrics.includes('blind_peer_core_activations 0'), 'blind_peer_core_activations included')
+    t.ok(
+      metrics.includes('blind_peer_active_replication_sessions 0'),
+      'blind_peer_active_replication_sessions included'
+    )
+    t.ok(
+      metrics.includes('blind_peer_replication_sessions_opened 0'),
+      'blind_peer_replication_sessions_opened included'
+    )
     t.ok(metrics.includes('blind_peer_wakeups 0'), 'blind_peer_wakeups')
     t.ok(metrics.includes('blind_peer_db_flushes 0'), 'blind_peer_db_flushes')
     t.ok(metrics.includes('blind_peer_announced_cores 0'), 'blind_peer_announced_cores')
@@ -2488,46 +2496,52 @@ test('coreTracker does not leak when core closes before refresh completes', asyn
   t.is(blindPeer.stats.coreTrackersDestroyed, 1, 'core trackers destroyed stat')
 })
 
-test('activating the same core repeatedly does not leak hypercore sessions and stream close listeners', async (t) => {
-  // Repeated add-core requests happen when an autobase changes,
-  // but to keep the tests simple we hack into the muxer directly
-  // (the test is for the server side anyway)
+test(
+  'activating the same core repeatedly does not leak hypercore sessions and stream close listeners',
+  async (t) => {
+    // Repeated add-core requests happen when an autobase changes,
+    // but to keep the tests simple we hack into the muxer directly
+    // (the test is for the server side anyway)
 
-  const { bootstrap } = await getTestnet(t)
+    const { bootstrap } = await getTestnet(t)
 
-  const { blindPeer } = await setupBlindPeer(t, bootstrap)
-  await blindPeer.listen()
-  await blindPeer.swarm.flush()
+    const { blindPeer } = await setupBlindPeer(t, bootstrap)
+    await blindPeer.listen()
+    await blindPeer.swarm.flush()
 
-  const { core, swarm, store } = await setupCoreHolder(t, bootstrap, { active: false })
+    const { core, swarm, store } = await setupCoreHolder(t, bootstrap, { active: false })
 
-  const connProm = once(blindPeer.swarm, 'connection')
-  const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
-  const [conn] = await connProm
+    const connProm = once(blindPeer.swarm, 'connection')
+    const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
+    const [conn] = await connProm
 
-  const closeListeners = () => conn.listenerCount('close')
-  const initListeners = closeListeners()
+    const closeListeners = () => conn.listenerCount('close')
+    const initListeners = closeListeners()
 
-  for (let i = 0; i < 5; i++) {
-    await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
-    await Promise.all([
-      once(blindPeer, 'add-cores-done'),
-      muxer.addCores({
-        cores: [{ key: core.key, length: core.length }]
-      })
-    ])
+    for (let i = 0; i < 5; i++) {
+      await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
+      await Promise.all([
+        once(blindPeer, 'add-cores-done'),
+        muxer.addCores({
+          cores: [{ key: core.key, length: core.length }]
+        })
+      ])
+    }
+
+    t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
+
+    t.is(closeListeners() - initListeners, 1, `no close listener leak`)
+
+    const bpCore = blindPeer.store.get(core.key)
+    await bpCore.ready()
+    t.is(bpCore.sessions.length, 2, 'no new session per request')
+    t.is(blindPeer.getActiveReplicationSessions(), 1, 'blind peers own view correct')
+    t.is(blindPeer.stats.activatedReplications, 1, 'blind peers own stat correct')
+    await muxer.stream.destroy()
+    await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
+    t.is(blindPeer.getActiveReplicationSessions(), 0, 'blind peers own stat correct')
   }
-
-  t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
-
-  t.is(closeListeners() - initListeners, 1, `no close listener leak`)
-
-  const bpCore = blindPeer.store.get(core.key)
-  await bpCore.ready()
-  t.is(bpCore.sessions.length, 2, 'no new session per request')
-
-  await muxer.close()
-})
+)
 
 async function setupCoreHolder(t, bootstrap, { active } = {}) {
   const { swarm, store } = await setupPeer(t, bootstrap, { active })

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,6 @@ const { ADMIN_CHANNEL_ID, AdminQueryTopKEncoding } = require('blind-peer-encodin
 const blindPush = require('blind-push')
 const BlindPushGateway = require('blind-push-gateway')
 const rrp = require('resolve-reject-promise')
-const HypercoreStats = require('hypercore-stats')
 
 const BlindPeer = require('..')
 const TopKWindow = require('../lib/top-k.js')

--- a/test/test.js
+++ b/test/test.js
@@ -2518,11 +2518,12 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
     ])
   }
 
-  t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation')
-  const bpCore = blindPeer.store.get(core.key)
-  await bpCore.ready()
+  t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
 
   t.is(closeListeners() - initListeners, 1, `no close listener leak`)
+
+  const bpCore = blindPeer.store.get(core.key)
+  await bpCore.ready()
   t.is(bpCore.sessions.length, 2, 'no new session per request')
 
   await muxer.close()

--- a/test/test.js
+++ b/test/test.js
@@ -2513,8 +2513,7 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
   const muxer = await setupMuxer(t, swarm, store, blindPeer.publicKey)
   const [conn] = await connProm
 
-  const closeListeners = () => conn.listenerCount('close')
-  const initListeners = closeListeners()
+  const initListeners = conn.listenerCount('close')
 
   for (let i = 0; i < 5; i++) {
     await core.append(`Block ${i + 1}`) // ensure length differs so needsActivation is set
@@ -2528,15 +2527,15 @@ test('activating the same core repeatedly does not leak hypercore sessions and s
 
   t.is(blindPeer.stats.activations, 5, 'each add-cores triggered an activation (sanity check)')
 
-  t.is(closeListeners() - initListeners, 1, `no close listener leak`)
+  t.is(conn.listenerCount('close') - initListeners, 1, `no close listener leak`)
 
   const bpCore = blindPeer.store.get(core.key)
   await bpCore.ready()
   t.is(bpCore.sessions.length, 2, 'no new session per request')
   t.is(blindPeer.getActiveReplicationSessions(), 1, 'blind peers own view correct')
   t.is(blindPeer.stats.activatedReplications, 1, 'blind peers own stat correct')
-  await muxer.stream.destroy()
-  await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
+  await Promise.all([new Promise((resolve) => conn.once('close', resolve)), muxer.stream.destroy()])
+  // await new Promise((resolve) => setTimeout(resolve, 100)) // Some timing involved (0 does not always work)
   t.is(blindPeer.getActiveReplicationSessions(), 0, 'blind peers own stat correct')
 })
 


### PR DESCRIPTION
Previous behaviour:  when addCores results in an activation (length changed), an additional hypercore session is created. This is useless, because there is already a session with replication setup for the same connection. The fix avoids the duplicates.

A side effect of the fix is that when a udx stream leaks (the conn/stream object), it no longer retains all the associated hypercore sessions (previously, the conn.on('close') handler kept all hypercore session objects in memory as long as it was referenced). This mitigates the effect of an unrelated bug in hyperdht which leaks streams.


AI Disclaimer: the test was made with the help of AI (fix not)