### PR TITLE
test peer destroy()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
-        with:
-          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
-        with:
-          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
+        with:
+          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
+        with:
+          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "holepunchto/blind-peering#cleanup_on_destroy()",
+    "blind-peering": "^2.6.1",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "^2.5.3",
+    "blind-peering": "holepunchto/blind-peering#cleanup_on_destroy()",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -3052,6 +3052,7 @@ test('destroying peer in blind-peering clears listeners', async (t) => {
   await blindPeer.swarm.flush()
 
   const { swarm, store, base } = await setupAutobaseHolder(t, bootstrap)
+  t.teardown(() => base.close())
   await base.append({ hello: 'world' })
 
   const core = store.get({ name: 'core' })

--- a/test/test.js
+++ b/test/test.js
@@ -3045,6 +3045,59 @@ test('sendNotification does not create a second ref to an already-added blind pe
   t.is(client.blindPeers.size, 1, 'sendNotification reused the existing ref')
 })
 
+test.solo('destroying peer in blind-peering clears listeners', async (t) => {
+  const { bootstrap } = await getTestnet(t)
+
+  const { blindPeer } = await setupBlindPeer(t, bootstrap)
+  await blindPeer.swarm.flush()
+
+  const { swarm, store, base } = await setupAutobaseHolder(t, bootstrap)
+  await base.append({ hello: 'world' })
+
+  const core = store.get({ name: 'core' })
+  await core.append('block-0')
+
+  const core2 = store.get({ name: 'core2' })
+  await core2.append('block-0')
+
+  const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
+
+  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners initially')
+  t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners initially')
+  t.is(base.core.listenerCount('migrate'), 0, 'base core 0 "migrate" liteners initially')
+
+  client.addCoreBackground(core, { pick: 5 })
+  client.addCoreBackground(core, { pick: 10 })
+  await client.addAutobase(base)
+
+  const peer = client.blindPeers.get(b4a.toString(blindPeer.publicKey, 'hex'))
+
+  t.is(peer.cores.size, 1, '1 core is added despite adding it twice')
+  t.is(peer.cores.values().next().value.pick, 10, 'info object is from the second addition')
+
+  t.is(core.listenerCount('close'), 1, 'core 1 "close" listener despite adding it twice')
+  t.is(base.listenerCount('close'), 1, 'base 1 "close" listener after adding')
+  t.is(base.core.listenerCount('migrate'), 1, 'base core 1 "close" listener after adding')
+
+  await client.addCore(core2)
+  t.is(core2.listenerCount('close'), 1, 'core2 1 listener after adding')
+  await core2.close()
+  t.is(core2.listenerCount('close'), 0, 'core2 0 listeners after core close')
+
+  await client.close()
+  t.is(peer.destroyed, true, 'closing blind-peering destroyed the peer')
+
+  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners after peer is destroyed')
+  t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners after peer is destroyed')
+  t.is(
+    base.core.listenerCount('migrate'),
+    0,
+    'base core 0 "migrate" listeners after peer is destroyed'
+  )
+  t.is(peer.cores.size, 0, 'destroy() clears the cores map of the peer')
+  t.is(peer.bases.size, 0, 'destroy() clears the bases map of the peer')
+})
+
 async function setupAdminClient(t, { bootstrap = null, serverPublicKey, keyPair }) {
   const dht = new HyperDHT({ bootstrap, keyPair })
   t.teardown(() => dht.destroy(), { order: 4000 })

--- a/test/test.js
+++ b/test/test.js
@@ -3045,7 +3045,7 @@ test('sendNotification does not create a second ref to an already-added blind pe
   t.is(client.blindPeers.size, 1, 'sendNotification reused the existing ref')
 })
 
-test.solo('destroying peer in blind-peering clears listeners', async (t) => {
+test('destroying peer in blind-peering clears listeners', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { blindPeer } = await setupBlindPeer(t, bootstrap)

--- a/test/test.js
+++ b/test/test.js
@@ -3045,7 +3045,41 @@ test('sendNotification does not create a second ref to an already-added blind pe
   t.is(client.blindPeers.size, 1, 'sendNotification reused the existing ref')
 })
 
-test('destroying peer in blind-peering clears listeners', async (t) => {
+test('destroying a peer in blind-peering clears core listeners', async (t) => {
+  const { bootstrap } = await getTestnet(t)
+
+  const { blindPeer } = await setupBlindPeer(t, bootstrap)
+  await blindPeer.swarm.flush()
+
+  const { swarm, store, core } = await setupCoreHolder(t, bootstrap)
+  const core2 = store.get({ name: 'core2' })
+  await core2.append('block-0')
+
+  const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
+
+  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners initially')
+  t.is(core2.listenerCount('close'), 0, 'core2 0 "close" listeners initially')
+
+  await client.addCore(core)
+  await client.addCore(core2)
+
+  t.is(core.listenerCount('close'), 1, 'core 1 "close" listener after adding')
+  t.is(core2.listenerCount('close'), 1, 'core2 1 "close" listener after adding')
+
+  await core2.close()
+
+  t.is(core2.listenerCount('close'), 0, 'core2 0 listeners after core2 close')
+
+  const peer = client.blindPeers.get(b4a.toString(blindPeer.publicKey, 'hex'))
+
+  await client.close()
+
+  t.is(peer.destroyed, true, 'closing blind-peering destroyed the peer')
+  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners after peer is destroyed')
+  t.is(peer.cores.size, 0, 'destroy() clears the cores map of the peer')
+})
+
+test('destroying peer in blind-peering clears autobase listeners', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { blindPeer } = await setupBlindPeer(t, bootstrap)
@@ -3055,47 +3089,27 @@ test('destroying peer in blind-peering clears listeners', async (t) => {
   t.teardown(() => base.close())
   await base.append({ hello: 'world' })
 
-  const core = store.get({ name: 'core' })
-  await core.append('block-0')
-
-  const core2 = store.get({ name: 'core2' })
-  await core2.append('block-0')
-
   const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
 
-  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners initially')
   t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners initially')
   t.is(base.core.listenerCount('migrate'), 0, 'base core 0 "migrate" liteners initially')
 
-  client.addCoreBackground(core, { pick: 5 })
-  client.addCoreBackground(core, { pick: 10 })
   await client.addAutobase(base)
+
+  t.is(base.listenerCount('close'), 1, 'base 1 "close" listener after adding')
+  t.is(base.core.listenerCount('migrate'), 1, 'base core 1 "migrate" listener after adding')
 
   const peer = client.blindPeers.get(b4a.toString(blindPeer.publicKey, 'hex'))
 
-  t.is(peer.cores.size, 1, '1 core is added despite adding it twice')
-  t.is(peer.cores.values().next().value.pick, 10, 'info object is from the second addition')
-
-  t.is(core.listenerCount('close'), 1, 'core 1 "close" listener despite adding it twice')
-  t.is(base.listenerCount('close'), 1, 'base 1 "close" listener after adding')
-  t.is(base.core.listenerCount('migrate'), 1, 'base core 1 "close" listener after adding')
-
-  await client.addCore(core2)
-  t.is(core2.listenerCount('close'), 1, 'core2 1 listener after adding')
-  await core2.close()
-  t.is(core2.listenerCount('close'), 0, 'core2 0 listeners after core close')
-
   await client.close()
-  t.is(peer.destroyed, true, 'closing blind-peering destroyed the peer')
 
-  t.is(core.listenerCount('close'), 0, 'core 0 "close" listeners after peer is destroyed')
+  t.is(peer.destroyed, true, 'closing blind-peering destroyed the peer')
   t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners after peer is destroyed')
   t.is(
     base.core.listenerCount('migrate'),
     0,
     'base core 0 "migrate" listeners after peer is destroyed'
   )
-  t.is(peer.cores.size, 0, 'destroy() clears the cores map of the peer')
   t.is(peer.bases.size, 0, 'destroy() clears the bases map of the peer')
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -3092,11 +3092,13 @@ test('destroying peer in blind-peering clears autobase listeners', async (t) => 
   const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
 
   t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners initially')
+  t.is(base.listenerCount('writer'), 0, 'base 0 "writer" liteners initially')
   t.is(base.core.listenerCount('migrate'), 0, 'base core 0 "migrate" liteners initially')
 
   await client.addAutobase(base)
 
   t.is(base.listenerCount('close'), 1, 'base 1 "close" listener after adding')
+  t.is(base.listenerCount('writer'), 1, 'base 1 "writer" liteners after adding')
   t.is(base.core.listenerCount('migrate'), 1, 'base core 1 "migrate" listener after adding')
 
   const peer = client.blindPeers.get(b4a.toString(blindPeer.publicKey, 'hex'))
@@ -3105,6 +3107,7 @@ test('destroying peer in blind-peering clears autobase listeners', async (t) => 
 
   t.is(peer.destroyed, true, 'closing blind-peering destroyed the peer')
   t.is(base.listenerCount('close'), 0, 'base 0 "close" listeners after peer is destroyed')
+  t.is(base.listenerCount('writer'), 0, 'base 0 "writer" listeners after peer is destroyed')
   t.is(
     base.core.listenerCount('migrate'),
     0,


### PR DESCRIPTION
First run shows how existing behavior fails:
https://github.com/holepunchto/blind-peer/actions/runs/31001800366/job/92292186377


AI usage:
This is a bug found by AI. Confirmed the behavior. Half of the reported issue was expected, but half is real. 
The test is simplified a lot from what AI generated, and additionally tests the accumulation of listeners over same core when that core is added multiple times(the core itself is deduped, but listeners accumulate in some specific conditions).