### PR TITLE
fix flaky test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3155,6 +3155,8 @@ test('destroying peer in blind-peering clears autobase listeners', async (t) => 
 
 test('db flush updates correctly for existing records', async (t) => {
   const addCore = async (info) => {
+    // slight wait between flushes, so that record timestamps always increase
+    // more than 1ms due to the flakiness with ms rounding
     await new Promise((resolve) => setTimeout(resolve, 10))
     blindPeer.db.addCore(info)
     await blindPeer.flush()

--- a/test/test.js
+++ b/test/test.js
@@ -3155,7 +3155,7 @@ test('destroying peer in blind-peering clears autobase listeners', async (t) => 
 
 test('db flush updates correctly for existing records', async (t) => {
   const addCore = async (info) => {
-    await new Promise((resolve) => setTimeout(resolve, 1))
+    await new Promise((resolve) => setTimeout(resolve, 10))
     blindPeer.db.addCore(info)
     await blindPeer.flush()
   }
@@ -3165,8 +3165,7 @@ test('db flush updates correctly for existing records', async (t) => {
   await blindPeer.ready()
 
   const key = crypto.randomBytes(32)
-  blindPeer.db.addCore({ key, priority: 0 })
-  await blindPeer.flush()
+  await addCore({ key, priority: 0 })
 
   const initialRecord = await blindPeer.db.getCoreRecord(key)
   // sanity check initial values on new record


### PR DESCRIPTION
Flaked due to millisecond rounding. Locally was failing in ~100 runs.

I've considered making it deterministic instead of relying on timeouts, with something like this:

```js
  let dateNow = 0
  const realNow = Date.now
  const addCore = async (info) => {
    try {
      Date.now = () => ++dateNow
      blindPeer.db.addCore(info)
      await blindPeer.flush()
    } finally {
      Date.now = realNow
    }
  }
```

But it's kinda ugly. The timeouts here add 60ms in total, which is very short. But should remove the flakiness completely. Locally did not fail in ~2000 runs.