### PR TITLE
Test notification sending for not ready cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
-        with:
-          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
-        with:
-          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
+        with:
+          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
+        with:
+          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "holepunchto/blind-peering#ready-notification-core",
+    "blind-peering": "^2.6.2",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "^2.6.1",
+    "blind-peering": "holepunchto/blind-peering#ready-notification-core",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -410,7 +410,7 @@ test('push notification timeout when getting block does not error the connection
   await store.close()
 })
 
-test.solo('blind-peering handles not ready cores for push notifications', async (t) => {
+test('blind-peering handles not ready cores for push notifications', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { gateway, sentMessages } = await setupPushGateway(t, bootstrap)

--- a/test/test.js
+++ b/test/test.js
@@ -410,6 +410,36 @@ test('push notification timeout when getting block does not error the connection
   await store.close()
 })
 
+test.solo('blind-peering handles not ready cores for push notifications', async (t) => {
+  const { bootstrap } = await getTestnet(t)
+
+  const { gateway, sentMessages } = await setupPushGateway(t, bootstrap)
+  const { blindPeer } = await initBlindPeer(t, bootstrap, {
+    pushGatewayKeys: [gateway.publicKey]
+  })
+
+  const { core, swarm, store } = await setupCoreHolder(t, bootstrap)
+  await core.setUserData('referrer', core.key)
+
+  const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
+  t.teardown(async () => await client.close())
+
+  await Promise.all([once(blindPeer, 'add-cores-done'), client.addCore(core)])
+
+  {
+    const core = store.get({ name: 'core' })
+    await core.ready()
+    await Promise.all([once(blindPeer, 'notification-sent'), client.sendNotification(core)])
+    t.is(sentMessages.length, 1, 'push gateway received the notification when core was ready')
+  }
+
+  {
+    const core = store.get({ name: 'core' })
+    await Promise.all([once(blindPeer, 'notification-sent'), client.sendNotification(core)])
+    t.is(sentMessages.length, 2, 'push gateway received the notification when core was not ready')
+  }
+})
+
 test('client can use a blind-peer to add an autobase', async (t) => {
   const tFirstAdd = t.test()
   tFirstAdd.plan(1)
@@ -3139,13 +3169,18 @@ async function setupBlindPeer(
   return { blindPeer: peer, storage }
 }
 
+async function initBlindPeer(t, bootstrap, opts) {
+  const result = await setupBlindPeer(t, bootstrap, opts)
+  await result.blindPeer.listen()
+  await result.blindPeer.swarm.flush()
+  return result
+}
+
 async function setupBlindPeers(t, bootstrap, amount) {
   const blindPeers = []
 
   for (let i = 0; i < amount; i++) {
-    const { blindPeer } = await setupBlindPeer(t, bootstrap)
-    await blindPeer.listen()
-    await blindPeer.swarm.flush()
+    const { blindPeer } = await initBlindPeer(t, bootstrap)
     blindPeers.push(blindPeer)
   }
 


### PR DESCRIPTION
Failing run: https://github.com/holepunchto/blind-peer/actions/runs/31568842308/job/94026299808
To undraft, need to released: https://github.com/holepunchto/blind-peering/pull/76

I briefly checked how we use it now, I don't think it's being hit at the moment.
Did the fix now as the test and fix are both really simple.