### PR TITLE
Test client gc during notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
-        with:
-          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
-        with:
-          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: holepunchto/actions/bare-base@v1
+        with:
+          allow-git: root
       - run: npm test
       - run: npm run test:bare
   test-netns:
     runs-on: ubuntu-latest
     steps:
       - uses: holepunchto/actions/node-base@v1
+        with:
+          allow-git: root
       - name: Setup network namespaces
         run: sudo test-netns/scripts/setup.sh
       - name: Run netns tests

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "holepunchto/blind-peering#fix-gc-during-notifications",
+    "blind-peering": "^2.6.3",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-process": "^4.2.2",
     "bare-prom-client": "^15.1.3",
     "blind-peer-router": "^0.2.2",
-    "blind-peering": "^2.6.2",
+    "blind-peering": "holepunchto/blind-peering#fix-gc-during-notifications",
     "blind-push-gateway": "^1.0.0",
     "brittle": "^3.7.0",
     "debounceify": "^1.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1959,6 +1959,45 @@ test('client gc logic', async (t) => {
   await client.close()
 })
 
+test.solo('client does not gc peers with pending notifications', async (t) => {
+  const { bootstrap } = await getTestnet(t)
+  const { blindPeer } = await initBlindPeer(t, bootstrap)
+  const { core, swarm, store } = await setupCoreHolder(t, bootstrap)
+
+  const client = new Client(swarm.dht, store, {
+    keys: [blindPeer.publicKey],
+    gcWait: 10_000
+  })
+  t.teardown(async () => await client.close())
+
+  await Promise.all([once(blindPeer, 'add-cores-done'), client.addCore(core)])
+  const peer = client.blindPeers.values().next().value
+
+  // block mid-sendNotification to test state mid-flight
+  const { promise, resolve } = rrp()
+  const send = peer.channel.sendNotification.bind(peer.channel)
+  peer.channel.sendNotification = async (request) => {
+    await promise
+    return send(request)
+  }
+
+  t.absent(client._gc.has(peer), 'peer is not gc candidate while it has core')
+  await core.close()
+  t.ok(client._gc.has(peer), 'peer is gc candidate after core closed')
+
+  const sendNotification = client.sendNotification(store.get({ name: 'core' }))
+  await sleep(100)
+
+  t.is(peer.pendingNotifications, 1, 'peer has pending notification')
+  t.absent(client._gc.has(peer), 'peer left gc')
+
+  resolve()
+  await sendNotification
+
+  t.is(peer.pendingNotifications, 0, 'peer has no pending notifications')
+  t.ok(client._gc.has(peer), 'peer is gc candidate after notification was sent')
+})
+
 test('client destroys pending timeouts on close', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
@@ -3553,4 +3592,8 @@ async function getWakeupPeer(t, bootstrap, indexer, blindPeer) {
   })
 
   return { client, base, store, swarm, wakeup: base.wakeupProtocol }
+}
+
+function sleep(delay = 1000) {
+  return new Promise((resolve) => setTimeout(resolve, delay))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1959,7 +1959,7 @@ test('client gc logic', async (t) => {
   await client.close()
 })
 
-test.solo('client gc accounts for pending notifications', async (t) => {
+test('client gc accounts for pending notifications', async (t) => {
   const { bootstrap } = await getTestnet(t)
   const { blindPeer } = await initBlindPeer(t, bootstrap)
   const { core, swarm, store } = await setupCoreHolder(t, bootstrap)

--- a/test/test.js
+++ b/test/test.js
@@ -1959,7 +1959,7 @@ test('client gc logic', async (t) => {
   await client.close()
 })
 
-test.solo('client does not gc peers with pending notifications', async (t) => {
+test.solo('client gc accounts for pending notifications', async (t) => {
   const { bootstrap } = await getTestnet(t)
   const { blindPeer } = await initBlindPeer(t, bootstrap)
   const { core, swarm, store } = await setupCoreHolder(t, bootstrap)
@@ -1981,9 +1981,9 @@ test.solo('client does not gc peers with pending notifications', async (t) => {
     return send(request)
   }
 
-  t.absent(client._gc.has(peer), 'peer is not gc candidate while it has core')
+  t.absent(client._gc.has(peer), 'peer is not gc candidate while it has a core')
   await core.close()
-  t.ok(client._gc.has(peer), 'peer is gc candidate after core closed')
+  t.ok(client._gc.has(peer), 'peer entered gc after core was closed')
 
   const sendNotification = client.sendNotification(store.get({ name: 'core' }))
   await sleep(100)
@@ -1995,7 +1995,7 @@ test.solo('client does not gc peers with pending notifications', async (t) => {
   await sendNotification
 
   t.is(peer.pendingNotifications, 0, 'peer has no pending notifications')
-  t.ok(client._gc.has(peer), 'peer is gc candidate after notification was sent')
+  t.ok(client._gc.has(peer), 'peer entered gc after notification was sent')
 })
 
 test('client destroys pending timeouts on close', async (t) => {


### PR DESCRIPTION
Fails to exit gc while sending notification: https://github.com/holepunchto/blind-peer/actions/runs/31676629103/job/94372512413?pr=189
Fails to re-enter gc after notification is sent: https://github.com/holepunchto/blind-peer/actions/runs/31679981788/job/94382989716?pr=189

Undraft after: https://github.com/holepunchto/blind-peering/pull/78 is released

