### PR TITLE
add core debug info to notification error

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,7 @@ class BlindPeer extends ReadyResource {
       activeCorestore = false,
       treeCache,
       notificationTimeout = 10000,
+      notificationErrorSnapshotDelay = 30_000,
       retryRecordLookupTimeout = 5000
     } = {}
   ) {
@@ -247,6 +248,7 @@ class BlindPeer extends ReadyResource {
     this.ipBanLists = ipBanListKeys.map((key) => new IpBanList(ipBanNs, { key }))
     this.banTimeout = banTimeout
     this.notificationTimeout = notificationTimeout
+    this.notificationErrorSnapshotDelay = notificationErrorSnapshotDelay
 
     this._port = port || 0
     this.bootstrap = bootstrap
@@ -1019,14 +1021,45 @@ class BlindPeer extends ReadyResource {
         await this._activateCore(stream, record)
       }
 
-      const payload = await blindPush.createNotification(core, {
-        roomKey: request.destination.key,
-        roomDiscoveryKey: request.destination.discoveryKey,
-        index: request.block.index,
-        version: request.version,
-        extra: request.extra,
-        timeout: this.notificationTimeout
-      })
+      const senderPublicKey = stream.remotePublicKey
+      const coreInfoBefore = snapshotCoreInfo(core, senderPublicKey)
+
+      let payload = null
+      try {
+        payload = await blindPush.createNotification(core, {
+          roomKey: request.destination.key,
+          roomDiscoveryKey: request.destination.discoveryKey,
+          index: request.block.index,
+          version: request.version,
+          extra: request.extra,
+          timeout: this.notificationTimeout
+        })
+      } catch (e) {
+        const coreInfoOnError = snapshotCoreInfo(core, senderPublicKey)
+
+        setTimeout(async () => {
+          try {
+            const snapshotCore = this.store.get({ key: request.block.key })
+            await snapshotCore.ready()
+
+            try {
+              const coreInfoAfterDelay = snapshotCoreInfo(snapshotCore, senderPublicKey)
+
+              this.emit('notification-error-snapshot', {
+                coreInfoBefore,
+                coreInfoOnError,
+                coreInfoAfterDelay
+              })
+            } finally {
+              await snapshotCore.close()
+            }
+          } catch (e) {
+            console.warn('error when notify', e)
+          }
+        }, this.notificationErrorSnapshotDelay).unref()
+
+        throw e
+      }
 
       await this.gatewayPool.makeRequest(
         'forward-push',
@@ -1355,6 +1388,58 @@ class BlindPeer extends ReadyResource {
         }
       })
     }
+  }
+}
+
+function snapshotCoreInfo(core, senderPublicKey) {
+  try {
+    const senderPeer = core.peers.find((peer) => b4a.equals(peer.remotePublicKey, senderPublicKey))
+
+    return {
+      length: core.length,
+      contiguousLength: core.contiguousLength,
+      byteLength: core.byteLength,
+      fork: core.fork,
+      peerCount: core.peers.length,
+      senderPeer: senderPeer
+        ? {
+            remotePublicKey: IdEnc.normalize(senderPeer.remotePublicKey),
+            removed: senderPeer.removed,
+            paused: senderPeer.paused,
+            remoteLength: senderPeer.remoteLength,
+            remoteContiguousLength: senderPeer.remoteContiguousLength,
+            remoteFork: senderPeer.remoteFork,
+            lengthAcked: senderPeer.lengthAcked,
+            inflight: senderPeer.inflight,
+            maxInflight: senderPeer.getMaxInflight(),
+            wireRequestTx: senderPeer.stats.wireRequest.tx,
+            wireDataRx: senderPeer.stats.wireData.rx,
+            backoffs: senderPeer.stats.backoffs,
+            notAvailableBackoffs: senderPeer.stats.notAvailableBackoffs,
+            hotswaps: senderPeer.stats.hotswaps,
+            rtt: senderPeer.stream.rawStream.rtt,
+            stream: {
+              destroying: senderPeer.stream.destroying,
+              destroyed: senderPeer.stream.destroyed,
+              rawBytesWritten: senderPeer.stream.rawBytesWritten,
+              rawBytesRead: senderPeer.stream.rawBytesRead,
+              rawStream: {
+                destroying: senderPeer.stream.rawStream.destroying,
+                destroyed: senderPeer.stream.rawStream.destroyed,
+                mtu: senderPeer.stream.rawStream.mtu,
+                rtt: senderPeer.stream.rawStream.rtt,
+                cwnd: senderPeer.stream.rawStream.cwnd,
+                inflight: senderPeer.stream.rawStream.inflight,
+                rtoCount: senderPeer.stream.rawStream.rtoCount,
+                retransmits: senderPeer.stream.rawStream.retransmits
+              }
+            }
+          }
+        : null
+    }
+  } catch (e) {
+    console.warn(e)
+    return null
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1024,7 +1024,7 @@ class BlindPeer extends ReadyResource {
       }
 
       const senderPublicKey = stream.remotePublicKey
-      const coreInfoBefore = this._snapshotCore(core, senderPublicKey)
+      const coreInfoBefore = this._snapshotCore(core, senderPublicKey, request.block.index)
 
       let payload = null
       try {
@@ -1037,7 +1037,7 @@ class BlindPeer extends ReadyResource {
           timeout: this.notificationTimeout
         })
       } catch (e) {
-        const coreInfoOnError = this._snapshotCore(core, senderPublicKey)
+        const coreInfoOnError = this._snapshotCore(core, senderPublicKey, request.block.index)
 
         // temp, no semver guarantees
         setTimeout(async () => {
@@ -1048,7 +1048,11 @@ class BlindPeer extends ReadyResource {
             await snapshotCore.ready()
 
             try {
-              const coreInfoAfterDelay = this._snapshotCore(snapshotCore, senderPublicKey)
+              const coreInfoAfterDelay = this._snapshotCore(
+                snapshotCore,
+                senderPublicKey,
+                request.block.index
+              )
 
               // temp, no semver guarantees
               this.emit('notification-error-snapshot', {
@@ -1083,7 +1087,7 @@ class BlindPeer extends ReadyResource {
     }
   }
 
-  _snapshotCore(core, senderPublicKey) {
+  _snapshotCore(core, senderPublicKey, requestBlockIndex) {
     try {
       const senderPeer = core.peers.find((peer) =>
         b4a.equals(peer.remotePublicKey, senderPublicKey)
@@ -1103,6 +1107,8 @@ class BlindPeer extends ReadyResource {
               remoteLength: senderPeer.remoteLength,
               remoteContiguousLength: senderPeer.remoteContiguousLength,
               remoteFork: senderPeer.remoteFork,
+              remoteUploading: senderPeer.remoteUploading,
+              hasBlock: senderPeer.remoteBitfield.get(requestBlockIndex),
               lengthAcked: senderPeer.lengthAcked,
               inflight: senderPeer.inflight,
               maxInflight: senderPeer.getMaxInflight(),

--- a/index.js
+++ b/index.js
@@ -235,6 +235,7 @@ class BlindPeer extends ReadyResource {
       activeCorestore = false,
       treeCache,
       notificationTimeout = 10000,
+      // temp, no semver guarantees
       notificationErrorSnapshotDelay = 30_000,
       retryRecordLookupTimeout = 5000
     } = {}
@@ -248,6 +249,7 @@ class BlindPeer extends ReadyResource {
     this.ipBanLists = ipBanListKeys.map((key) => new IpBanList(ipBanNs, { key }))
     this.banTimeout = banTimeout
     this.notificationTimeout = notificationTimeout
+    // temp, no semver guarantees
     this.notificationErrorSnapshotDelay = notificationErrorSnapshotDelay
 
     this._port = port || 0
@@ -1022,7 +1024,7 @@ class BlindPeer extends ReadyResource {
       }
 
       const senderPublicKey = stream.remotePublicKey
-      const coreInfoBefore = snapshotCoreInfo(core, senderPublicKey)
+      const coreInfoBefore = this._snapshotCore(core, senderPublicKey)
 
       let payload = null
       try {
@@ -1035,16 +1037,20 @@ class BlindPeer extends ReadyResource {
           timeout: this.notificationTimeout
         })
       } catch (e) {
-        const coreInfoOnError = snapshotCoreInfo(core, senderPublicKey)
+        const coreInfoOnError = this._snapshotCore(core, senderPublicKey)
 
+        // temp, no semver guarantees
         setTimeout(async () => {
+          if (this.closing) return
+
           try {
             const snapshotCore = this.store.get({ key: request.block.key })
             await snapshotCore.ready()
 
             try {
-              const coreInfoAfterDelay = snapshotCoreInfo(snapshotCore, senderPublicKey)
+              const coreInfoAfterDelay = this._snapshotCore(snapshotCore, senderPublicKey)
 
+              // temp, no semver guarantees
               this.emit('notification-error-snapshot', {
                 coreInfoBefore,
                 coreInfoOnError,
@@ -1054,7 +1060,7 @@ class BlindPeer extends ReadyResource {
               await snapshotCore.close()
             }
           } catch (e) {
-            console.warn('error when notify', e)
+            this.emit('warn', e)
           }
         }, this.notificationErrorSnapshotDelay).unref()
 
@@ -1074,6 +1080,60 @@ class BlindPeer extends ReadyResource {
       this.emit('notification-sent', request, payload, stream, Date.now() - startTime)
     } finally {
       await core.close()
+    }
+  }
+
+  _snapshotCore(core, senderPublicKey) {
+    try {
+      const senderPeer = core.peers.find((peer) =>
+        b4a.equals(peer.remotePublicKey, senderPublicKey)
+      )
+
+      return {
+        length: core.length,
+        contiguousLength: core.contiguousLength,
+        byteLength: core.byteLength,
+        fork: core.fork,
+        peerCount: core.peers.length,
+        senderPeer: senderPeer
+          ? {
+              remotePublicKey: IdEnc.normalize(senderPeer.remotePublicKey),
+              removed: senderPeer.removed,
+              paused: senderPeer.paused,
+              remoteLength: senderPeer.remoteLength,
+              remoteContiguousLength: senderPeer.remoteContiguousLength,
+              remoteFork: senderPeer.remoteFork,
+              lengthAcked: senderPeer.lengthAcked,
+              inflight: senderPeer.inflight,
+              maxInflight: senderPeer.getMaxInflight(),
+              wireRequestTx: senderPeer.stats.wireRequest.tx,
+              wireDataRx: senderPeer.stats.wireData.rx,
+              backoffs: senderPeer.stats.backoffs,
+              notAvailableBackoffs: senderPeer.stats.notAvailableBackoffs,
+              hotswaps: senderPeer.stats.hotswaps,
+              rtt: senderPeer.stream.rawStream.rtt,
+              stream: {
+                destroying: senderPeer.stream.destroying,
+                destroyed: senderPeer.stream.destroyed,
+                rawBytesWritten: senderPeer.stream.rawBytesWritten,
+                rawBytesRead: senderPeer.stream.rawBytesRead,
+                rawStream: {
+                  destroying: senderPeer.stream.rawStream.destroying,
+                  destroyed: senderPeer.stream.rawStream.destroyed,
+                  mtu: senderPeer.stream.rawStream.mtu,
+                  rtt: senderPeer.stream.rawStream.rtt,
+                  cwnd: senderPeer.stream.rawStream.cwnd,
+                  inflight: senderPeer.stream.rawStream.inflight,
+                  rtoCount: senderPeer.stream.rawStream.rtoCount,
+                  retransmits: senderPeer.stream.rawStream.retransmits
+                }
+              }
+            }
+          : null
+      }
+    } catch (e) {
+      this.emit('warn', e)
+      return null
     }
   }
 
@@ -1388,58 +1448,6 @@ class BlindPeer extends ReadyResource {
         }
       })
     }
-  }
-}
-
-function snapshotCoreInfo(core, senderPublicKey) {
-  try {
-    const senderPeer = core.peers.find((peer) => b4a.equals(peer.remotePublicKey, senderPublicKey))
-
-    return {
-      length: core.length,
-      contiguousLength: core.contiguousLength,
-      byteLength: core.byteLength,
-      fork: core.fork,
-      peerCount: core.peers.length,
-      senderPeer: senderPeer
-        ? {
-            remotePublicKey: IdEnc.normalize(senderPeer.remotePublicKey),
-            removed: senderPeer.removed,
-            paused: senderPeer.paused,
-            remoteLength: senderPeer.remoteLength,
-            remoteContiguousLength: senderPeer.remoteContiguousLength,
-            remoteFork: senderPeer.remoteFork,
-            lengthAcked: senderPeer.lengthAcked,
-            inflight: senderPeer.inflight,
-            maxInflight: senderPeer.getMaxInflight(),
-            wireRequestTx: senderPeer.stats.wireRequest.tx,
-            wireDataRx: senderPeer.stats.wireData.rx,
-            backoffs: senderPeer.stats.backoffs,
-            notAvailableBackoffs: senderPeer.stats.notAvailableBackoffs,
-            hotswaps: senderPeer.stats.hotswaps,
-            rtt: senderPeer.stream.rawStream.rtt,
-            stream: {
-              destroying: senderPeer.stream.destroying,
-              destroyed: senderPeer.stream.destroyed,
-              rawBytesWritten: senderPeer.stream.rawBytesWritten,
-              rawBytesRead: senderPeer.stream.rawBytesRead,
-              rawStream: {
-                destroying: senderPeer.stream.rawStream.destroying,
-                destroyed: senderPeer.stream.rawStream.destroyed,
-                mtu: senderPeer.stream.rawStream.mtu,
-                rtt: senderPeer.stream.rawStream.rtt,
-                cwnd: senderPeer.stream.rawStream.cwnd,
-                inflight: senderPeer.stream.rawStream.inflight,
-                rtoCount: senderPeer.stream.rawStream.rtoCount,
-                retransmits: senderPeer.stream.rawStream.retransmits
-              }
-            }
-          }
-        : null
-    }
-  } catch (e) {
-    console.warn(e)
-    return null
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -187,7 +187,7 @@ test('blind-peer can set treeCache options for corestore', async (t) => {
   t.is(blindPeer.notificationErrorSnapshotDelay, 30_000, 'got snapshot delay default')
 })
 
-test('push notification timeout when getting block does not close the connection and emits a delayed error snapshot', async (t) => {
+test('client can ask a blind-peer to create and forward a push notification', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { gateway, sentMessages } = await setupPushGateway(t, bootstrap)
@@ -368,7 +368,7 @@ test('send push notification falls back when closest blind peer times out', asyn
   t.is(sentMessages.length, 1, 'fallback blind peer forwarded one push')
 })
 
-test('push notification emits a delayed error snapshot and does not close connection', async (t) => {
+test('push notification timeout when getting block does not close the connection and emits a delayed error snapshot', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { gateway } = await setupPushGateway(t, bootstrap)
@@ -401,10 +401,11 @@ test('push notification emits a delayed error snapshot and does not close connec
 
   const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
   const notificationError = once(blindPeer, 'notification-error')
+  const snapshotPromise = once(blindPeer, 'notification-error-snapshot')
   const [[error]] = await Promise.all([notificationError, client.sendNotification(core)])
   t.is(error.code, 'REQUEST_TIMEOUT', 'emitted the original error')
 
-  const [snapshot] = await once(blindPeer, 'notification-error-snapshot')
+  const [snapshot] = await snapshotPromise
   t.ok(snapshot.coreInfoBefore, 'captured core info before notification')
   t.ok(snapshot.coreInfoOnError, 'captured core info when notification failed')
   t.ok(snapshot.coreInfoAfterDelay, 'captured core info after snapshot delay')

--- a/test/test.js
+++ b/test/test.js
@@ -184,6 +184,7 @@ test('blind-peer can set treeCache options for corestore', async (t) => {
 
   t.is(blindPeer.store.storage.treeCache.maxSize, 2 ** 17, 'got maxSize')
   t.is(blindPeer.store.storage.treeCache.maxAge, 1337, 'got maxAge')
+  t.is(blindPeer.notificationErrorSnapshotDelay, 30_000, 'got snapshot delay default')
 })
 
 test('client can ask a blind-peer to create and forward a push notification', async (t) => {
@@ -367,13 +368,14 @@ test('send push notification falls back when closest blind peer times out', asyn
   t.is(sentMessages.length, 1, 'fallback blind peer forwarded one push')
 })
 
-test('push notification timeout when getting block does not error the connection', async (t) => {
+test('push notification emits a delayed error snapshot and does not close connection', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { gateway } = await setupPushGateway(t, bootstrap)
   const { blindPeer } = await setupBlindPeer(t, bootstrap, {
     pushGatewayKeys: [gateway.publicKey],
-    notificationTimeout: 1000
+    notificationTimeout: 1000,
+    notificationErrorSnapshotDelay: 100
   })
   await blindPeer.listen()
   await blindPeer.swarm.flush()
@@ -388,7 +390,7 @@ test('push notification timeout when getting block does not error the connection
   const swarm = new Hyperswarm({ bootstrap })
   const store = new Corestore(await t.tmp())
 
-  blindPeer.swarm.on('connection', (conn, peerInfo) => {
+  blindPeer.swarm.on('connection', (conn) => {
     conn.on('error', (err) => {
       t.fail('connection should not error')
       console.error(err)
@@ -398,7 +400,14 @@ test('push notification timeout when getting block does not error the connection
   await core.append('Block2')
 
   const client = new Client(swarm.dht, store, { keys: [blindPeer.publicKey] })
-  await Promise.all([once(blindPeer, 'notification-error'), client.sendNotification(core)])
+  const notificationError = once(blindPeer, 'notification-error')
+  const [[error]] = await Promise.all([notificationError, client.sendNotification(core)])
+  t.is(error.code, 'REQUEST_TIMEOUT', 'emitted the original error')
+
+  const [snapshot] = await once(blindPeer, 'notification-error-snapshot')
+  t.ok(snapshot.coreInfoBefore, 'captured core info before notification')
+  t.ok(snapshot.coreInfoOnError, 'captured core info when notification failed')
+  t.ok(snapshot.coreInfoAfterDelay, 'captured core info after snapshot delay')
 
   // some time for swarm error to trigger if any
   await new Promise((resolve) => setTimeout(resolve, 500))
@@ -3218,6 +3227,7 @@ async function setupBlindPeer(
     pushGatewayKeys,
     pushGatewayPoolOpts,
     notificationTimeout,
+    notificationErrorSnapshotDelay,
     retryRecordLookupTimeout
   } = {}
 ) {
@@ -3239,6 +3249,7 @@ async function setupBlindPeer(
     adminRouter,
     activeCorestore,
     notificationTimeout,
+    notificationErrorSnapshotDelay,
     retryRecordLookupTimeout
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -187,7 +187,7 @@ test('blind-peer can set treeCache options for corestore', async (t) => {
   t.is(blindPeer.notificationErrorSnapshotDelay, 30_000, 'got snapshot delay default')
 })
 
-test('client can ask a blind-peer to create and forward a push notification', async (t) => {
+test('push notification timeout when getting block does not close the connection and emits a delayed error snapshot', async (t) => {
   const { bootstrap } = await getTestnet(t)
 
   const { gateway, sentMessages } = await setupPushGateway(t, bootstrap)


### PR DESCRIPTION
This PR adds diagnostic data to failed notification requests before and after timeouts, capturing core, peer, and connection states. If the data contains nothing sensitive, we can also log it in production, otherwise we can still guarded it behind debug on blind-peer-cli