### PR TITLE
add notification error verbose stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -1040,7 +1040,13 @@ class BlindPeer extends ReadyResource {
         const coreInfoOnError = this._snapshotCore(core, senderPublicKey, request.block.index)
 
         const snapshotCore = this.store.get({ key: request.block.key })
-        await snapshotCore.ready()
+        try {
+          await snapshotCore.ready()
+        } catch (readyError) {
+          this.emit('warn', readyError)
+          // throw the original error instead
+          throw e
+        }
 
         const downloadBlocks = []
 
@@ -1095,7 +1101,11 @@ class BlindPeer extends ReadyResource {
             stream.off('error', streamOnError)
             snapshotCore.off('download', onDownload)
 
-            await snapshotCore.close()
+            try {
+              await snapshotCore.close()
+            } catch (e) {
+              this.emit('warn', e)
+            }
           }
         }, this.notificationErrorSnapshotDelay).unref()
 

--- a/index.js
+++ b/index.js
@@ -1136,7 +1136,7 @@ class BlindPeer extends ReadyResource {
 
       return {
         ts: Date.now(),
-        localHasBlock: core.core.bitfield.get(requestBlockIndex),
+        hasBlock: core.core.bitfield.get(requestBlockIndex),
         length: core.length,
         contiguousLength: core.contiguousLength,
         byteLength: core.byteLength,
@@ -1151,7 +1151,7 @@ class BlindPeer extends ReadyResource {
               remoteContiguousLength: senderPeer.remoteContiguousLength,
               remoteFork: senderPeer.remoteFork,
               remoteUploading: senderPeer.remoteUploading,
-              hasBlock:
+              remoteHasBlock:
                 requestBlockIndex < senderPeer.remoteContiguousLength ||
                 senderPeer.remoteBitfield.get(requestBlockIndex),
               lengthAcked: senderPeer.lengthAcked,

--- a/index.js
+++ b/index.js
@@ -1039,32 +1039,63 @@ class BlindPeer extends ReadyResource {
       } catch (e) {
         const coreInfoOnError = this._snapshotCore(core, senderPublicKey, request.block.index)
 
+        const snapshotCore = this.store.get({ key: request.block.key })
+        await snapshotCore.ready()
+
+        const downloadBlocks = []
+
+        // monitoring block download
+        const onDownload = (index, byteLength, peer) => {
+          // do simple cap on blocks to log
+          if (downloadBlocks.length <= 20) {
+            downloadBlocks.push({
+              index,
+              byteLength,
+              peerPublicKey: IdEnc.normalize(peer.remotePublicKey),
+              ts: Date.now()
+            })
+          }
+        }
+        snapshotCore.on('download', onDownload)
+
+        // monitoring stream error
+        let streamError = null
+        const streamOnError = (error) => {
+          streamError = {
+            message: error.message,
+            code: error.code,
+            ts: Date.now()
+          }
+        }
+        stream.on('error', streamOnError)
+
         // temp, no semver guarantees
         setTimeout(async () => {
-          if (this.closing) return
-
           try {
-            const snapshotCore = this.store.get({ key: request.block.key })
-            await snapshotCore.ready()
+            if (this.closing) return
 
-            try {
-              const coreInfoAfterDelay = this._snapshotCore(
-                snapshotCore,
-                senderPublicKey,
-                request.block.index
-              )
+            const coreInfoAfterDelay = this._snapshotCore(
+              snapshotCore,
+              senderPublicKey,
+              request.block.index
+            )
 
-              // temp, no semver guarantees
-              this.emit('notification-error-snapshot', {
-                coreInfoBefore,
-                coreInfoOnError,
-                coreInfoAfterDelay
-              })
-            } finally {
-              await snapshotCore.close()
-            }
+            // temp, no semver guarantees
+            this.emit('notification-error-snapshot', {
+              streamError: streamError,
+              requestBlockIndex: request.block.index,
+              downloadedBlocks: downloadBlocks,
+              coreInfoBefore,
+              coreInfoOnError,
+              coreInfoAfterDelay
+            })
           } catch (e) {
             this.emit('warn', e)
+          } finally {
+            stream.off('error', streamOnError)
+            snapshotCore.off('download', onDownload)
+
+            await snapshotCore.close()
           }
         }, this.notificationErrorSnapshotDelay).unref()
 
@@ -1094,6 +1125,8 @@ class BlindPeer extends ReadyResource {
       )
 
       return {
+        ts: Date.now(),
+        localHasBlock: core.core.bitfield.get(requestBlockIndex),
         length: core.length,
         contiguousLength: core.contiguousLength,
         byteLength: core.byteLength,
@@ -1108,7 +1141,9 @@ class BlindPeer extends ReadyResource {
               remoteContiguousLength: senderPeer.remoteContiguousLength,
               remoteFork: senderPeer.remoteFork,
               remoteUploading: senderPeer.remoteUploading,
-              hasBlock: senderPeer.remoteBitfield.get(requestBlockIndex),
+              hasBlock:
+                requestBlockIndex < senderPeer.remoteContiguousLength ||
+                senderPeer.remoteBitfield.get(requestBlockIndex),
               lengthAcked: senderPeer.lengthAcked,
               inflight: senderPeer.inflight,
               maxInflight: senderPeer.getMaxInflight(),
@@ -1124,6 +1159,8 @@ class BlindPeer extends ReadyResource {
                 rawBytesWritten: senderPeer.stream.rawBytesWritten,
                 rawBytesRead: senderPeer.stream.rawBytesRead,
                 rawStream: {
+                  id: senderPeer.stream.rawStream.id,
+                  remoteId: senderPeer.stream.rawStream.remoteId,
                   destroying: senderPeer.stream.rawStream.destroying,
                   destroyed: senderPeer.stream.rawStream.destroyed,
                   mtu: senderPeer.stream.rawStream.mtu,
@@ -1131,7 +1168,12 @@ class BlindPeer extends ReadyResource {
                   cwnd: senderPeer.stream.rawStream.cwnd,
                   inflight: senderPeer.stream.rawStream.inflight,
                   rtoCount: senderPeer.stream.rawStream.rtoCount,
-                  retransmits: senderPeer.stream.rawStream.retransmits
+                  retransmits: senderPeer.stream.rawStream.retransmits,
+                  fastRecoveries: senderPeer.stream.rawStream.fastRecoveries,
+                  bytesTransmitted: senderPeer.stream.rawStream.bytesTransmitted,
+                  packetsTransmitted: senderPeer.stream.rawStream.packetsTransmitted,
+                  bytesReceived: senderPeer.stream.rawStream.bytesReceived,
+                  packetsReceived: senderPeer.stream.rawStream.packetsReceived
                 }
               }
             }

--- a/index.js
+++ b/index.js
@@ -1023,8 +1023,7 @@ class BlindPeer extends ReadyResource {
         await this._activateCore(stream, record)
       }
 
-      const senderPublicKey = stream.remotePublicKey
-      const coreInfoBefore = this._snapshotCore(core, senderPublicKey, request.block.index)
+      const coreInfoBefore = this._snapshotCore(core, stream.remotePublicKey, request.block.index)
 
       let payload = null
       try {
@@ -1037,77 +1036,10 @@ class BlindPeer extends ReadyResource {
           timeout: this.notificationTimeout
         })
       } catch (e) {
-        const coreInfoOnError = this._snapshotCore(core, senderPublicKey, request.block.index)
-
-        const snapshotCore = this.store.get({ key: request.block.key })
-        try {
-          await snapshotCore.ready()
-        } catch (readyError) {
-          this.emit('warn', readyError)
-          // throw the original error instead
-          throw e
-        }
-
-        const downloadBlocks = []
-
-        // monitoring block download
-        const onDownload = (index, byteLength, peer) => {
-          // do simple cap on blocks to log
-          if (downloadBlocks.length <= 20) {
-            downloadBlocks.push({
-              index,
-              byteLength,
-              peerPublicKey: IdEnc.normalize(peer.remotePublicKey),
-              ts: Date.now()
-            })
-          }
-        }
-        snapshotCore.on('download', onDownload)
-
-        // monitoring stream error
-        let streamError = null
-        const streamOnError = (error) => {
-          streamError = {
-            message: error.message,
-            code: error.code,
-            ts: Date.now()
-          }
-        }
-        stream.on('error', streamOnError)
-
-        // temp, no semver guarantees
-        setTimeout(async () => {
-          try {
-            if (this.closing) return
-
-            const coreInfoAfterDelay = this._snapshotCore(
-              snapshotCore,
-              senderPublicKey,
-              request.block.index
-            )
-
-            // temp, no semver guarantees
-            this.emit('notification-error-snapshot', {
-              streamError: streamError,
-              requestBlockIndex: request.block.index,
-              downloadedBlocks: downloadBlocks,
-              coreInfoBefore,
-              coreInfoOnError,
-              coreInfoAfterDelay
-            })
-          } catch (e) {
-            this.emit('warn', e)
-          } finally {
-            stream.off('error', streamOnError)
-            snapshotCore.off('download', onDownload)
-
-            try {
-              await snapshotCore.close()
-            } catch (e) {
-              this.emit('warn', e)
-            }
-          }
-        }, this.notificationErrorSnapshotDelay).unref()
+        // we want to catch everything here to prevent bugs in the debug flow from crashing the process
+        this._delaySnapshotOnNotificationError(coreInfoBefore, stream, request).catch((e) =>
+          this.emit('warn', e)
+        )
 
         throw e
       }
@@ -1124,6 +1056,68 @@ class BlindPeer extends ReadyResource {
       this.stats.notificationsSent++
       this.emit('notification-sent', request, payload, stream, Date.now() - startTime)
     } finally {
+      await core.close()
+    }
+  }
+
+  // temp, no semver guarantees
+  async _delaySnapshotOnNotificationError(coreInfoBefore, stream, request) {
+    const core = this.store.get({ key: request.block.key })
+    await core.ready()
+
+    // monitoring block download
+    const downloadBlocks = []
+    const onDownload = (index, byteLength, peer) => {
+      // do simple cap on blocks to log
+      if (downloadBlocks.length <= 20) {
+        downloadBlocks.push({
+          index,
+          byteLength,
+          peerPublicKey: IdEnc.normalize(peer.remotePublicKey),
+          ts: Date.now()
+        })
+      }
+    }
+    core.on('download', onDownload)
+
+    // monitoring stream error
+    let streamError = null
+    const streamOnError = (error) => {
+      streamError = {
+        message: error.message,
+        code: error.code,
+        ts: Date.now()
+      }
+    }
+    stream.on('error', streamOnError)
+
+    try {
+      const coreInfoOnError = this._snapshotCore(core, stream.remotePublicKey, request.block.index)
+
+      // wait briefly, then capture the snapshot again
+      await new Promise((resolve) => setTimeout(resolve, this.notificationErrorSnapshotDelay))
+
+      if (this.closing) return
+
+      const coreInfoAfterDelay = this._snapshotCore(
+        core,
+        stream.remotePublicKey,
+        request.block.index
+      )
+
+      // temp, no semver guarantees
+      this.emit('notification-error-snapshot', {
+        streamError: streamError,
+        requestBlockIndex: request.block.index,
+        downloadedBlocks: downloadBlocks,
+        coreInfoBefore,
+        coreInfoOnError,
+        coreInfoAfterDelay
+      })
+    } finally {
+      stream.off('error', streamOnError)
+      core.off('download', onDownload)
+
       await core.close()
     }
   }

--- a/index.js
+++ b/index.js
@@ -1095,7 +1095,9 @@ class BlindPeer extends ReadyResource {
       const coreInfoOnError = this._snapshotCore(core, stream.remotePublicKey, request.block.index)
 
       // wait briefly, then capture the snapshot again
-      await new Promise((resolve) => setTimeout(resolve, this.notificationErrorSnapshotDelay))
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.notificationErrorSnapshotDelay).unref()
+      )
 
       if (this.closing) return
 


### PR DESCRIPTION
This PR adds more monitoring stats for notification errors, including:

- Fix missing blockRequestIndex and hasBlock logic.
- Add udx stream id / remoteId, as suggested by Marcus and James.
- Add a stream error listener to capture actual errors, as suggested by Marcus.
- Add a block listener to detect whether blocks were downloaded by the sender peer or another peer, as suggested by James.
- Add additional raw UDX stats for packets and bytes sent/received.